### PR TITLE
fixed a comment typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -133,7 +133,7 @@
       </div>
       <!-- End Modal -->
 
-      <!-- Small modal -->
+      <!-- Full modal -->
       <div class="modal">
         <input id="modal-trigger-full" class="checkbox" type="checkbox">
         <div class="modal-overlay">


### PR DESCRIPTION
During the copypaste of code blocks a mistake was made while labeling with a comment the "full modal" block.